### PR TITLE
add secrets inherit

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -20,6 +20,7 @@ on:
         required: false
         type: string
         default: ""
+    secrets: inherit
 
 permissions:
   id-token: write

--- a/.github/workflows/linter-go.yaml
+++ b/.github/workflows/linter-go.yaml
@@ -7,6 +7,7 @@ on:
       main_branch:
         required: true
         type: string
+    secrets: inherit
 
 jobs:
   linter:

--- a/.github/workflows/main-deploy.yaml
+++ b/.github/workflows/main-deploy.yaml
@@ -22,6 +22,7 @@ on:
       helm_values_files:
         required: true
         type: string
+    secrets: inherit
 
 permissions:
   id-token: write
@@ -33,6 +34,7 @@ jobs:
   publish:
     name: Publish to Staging
     runs-on: ubuntu-latest
+    environment: staging
 
     steps:
     - name: Checkout code

--- a/.github/workflows/main-terraform.yaml
+++ b/.github/workflows/main-terraform.yaml
@@ -16,6 +16,7 @@ on:
       staging_tfvars_json:
         required: true
         type: string
+    secrets: inherit
 
 permissions:
   id-token: write

--- a/.github/workflows/pr-go.yaml
+++ b/.github/workflows/pr-go.yaml
@@ -4,6 +4,7 @@ on:
       go_private:
         required: true
         type: string
+    secrets: inherit
 
 jobs:
   test:

--- a/.github/workflows/pr-terraform.yaml
+++ b/.github/workflows/pr-terraform.yaml
@@ -13,6 +13,7 @@ on:
       working_directory:
         required: true
         type: string
+    secrets: inherit
 
 permissions:
   id-token: write

--- a/.github/workflows/release-deploy.yaml
+++ b/.github/workflows/release-deploy.yaml
@@ -22,6 +22,7 @@ on:
       helm_values_files:
         required: true
         type: string
+    secrets: inherit
 
 permissions:
   id-token: write
@@ -33,6 +34,7 @@ jobs:
   publish:
     name: Publish to Production
     runs-on: ubuntu-latest
+    environment: prod
 
     steps:
     - name: Checkout code

--- a/.github/workflows/release-terraform.yaml
+++ b/.github/workflows/release-terraform.yaml
@@ -16,6 +16,7 @@ on:
       prod_tfvars_json:
         required: true
         type: string
+    secrets: inherit
 
 permissions:
   id-token: write


### PR DESCRIPTION
Since all secrets used in the shared actions are always from the calling workflow we can add the `secrets: inherit` here so we don't need to do it in each repo.

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_callsecretsinherit

This was triggering a linter error: https://github.com/vimeda/translation-srv/runs/6524912703?check_suite_focus=true#step:4:104

Also added the environments in both staging and prod `publish` jobs.