### PR TITLE
update go linter

### DIFF
--- a/.github/workflows/linter-go.yaml
+++ b/.github/workflows/linter-go.yaml
@@ -36,6 +36,8 @@ jobs:
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_DOCKERFILE: true
           VALIDATE_TERRAFORM_TFLINT: true
+          VALIDATE_OPENAPI: true
+          VALIDATE_YAML: true
           GITHUB_TOKEN: ${{ secrets.GB_TOKEN_PRIVATE }}
 
   golang:
@@ -49,7 +51,9 @@ jobs:
           go-version: 1.18.x
 
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Configure git for private modules
         env:
@@ -57,8 +61,10 @@ jobs:
         run: git config --global url."https://${TOKEN}:x-oauth-basic@github.com/vimeda".insteadOf "https://github.com/vimeda"
 
       - name: Linter
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
+          version: latest
+          only-new-issues: true
           args: -c ./.github/linters/.golangci.yaml
         env:
           GITHUB_TOKEN: ${{ secrets.GB_TOKEN_PRIVATE }}


### PR DESCRIPTION
Update go linter so it only lints changed files, otherwise the next PR on some repos would have 100 files with linter issues to fix.
Also added some useful linters in superlinter, as OpenAPI files and yaml.