### PR TITLE
allow to pass build args

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -21,7 +21,7 @@ on:
         required: false
         type: string
         default: ""
-      docker_makefile_lambda_command:
+      build_args:
         required: false
         type: string
         default: ""
@@ -85,7 +85,7 @@ jobs:
         tags: ${{ steps.metadata-srv.outputs.tags }}
         build-args: |
           GITHUB_TOKEN=${{ secrets.GB_TOKEN_PRIVATE }}
-          LAMBDA=${{ inputs.docker_makefile_lambda_command }}
+          ${{ inputs.build_args }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new
       env:


### PR DESCRIPTION
Since some repos have different Dockerfiles for each type of build -- eg. Dockerfile.jobs, Dockerfiles.lambda, etc... -- it would be good to give the flexibility for each repo to send whatever build arguments they need. 

I will update every repo that was already using the `docker_makefile_lambda_command` input.