### PR TITLE
bump go version

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -40,7 +40,7 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
-      
+
     - name: Configure AWS Credentials
       id: aws
       uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/linter-go.yaml
+++ b/.github/workflows/linter-go.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v3
         with:
-          go-version: "^1.18.0"
+          go-version: "^1.19.0"
 
       - name: Checkout Code
         uses: actions/checkout@v3

--- a/.github/workflows/pr-terraform.yaml
+++ b/.github/workflows/pr-terraform.yaml
@@ -117,27 +117,27 @@ jobs:
             </details>
 
             #### Terraform Staging Plan 📖\`${{ steps.plan-staging.outcome }}\`
-            
+
             <details><summary>Show Staging Plan</summary>
-            
+
             \`\`\`\n
             ${process.env.PLAN_STAGING}
             \`\`\`
-            
+
             </details>
 
             #### Terraform Prod Plan 📖\`${{ steps.plan-prod.outcome }}\`
-            
+
             <details><summary>Show Prod Plan</summary>
-            
+
             \`\`\`\n
             ${process.env.PLAN_PROD}
             \`\`\`
-            
+
             </details>
-            
+
             *Pusher: @${{ github.actor }}, Action: \`${{ github.event_name }}\`, Working Directory: \`${{ env.tf_actions_working_dir }}\`, Workflow: \`${{ github.workflow }}\`*`;
-            
+
             // 3. If we have a comment, update it, otherwise create a new one
             if (botComment) {
               github.rest.issues.updateComment({

--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -11,8 +11,8 @@ jobs:
     - name: Setup go
       uses: actions/setup-go@v3
       with:
-        go-version: "^1.18.0"
-        
+        go-version: "^1.19.0"
+
     - name: Checkout code
       uses: actions/checkout@v3
 


### PR DESCRIPTION
Release notes: https://go.dev/doc/go1.19

It's a major release but it shouldn't be a problem upgrading from go1.18.
There is one change that might affect some of our services:
> [Command](https://tip.golang.org/pkg/os/exec/#Command) and [LookPath](https://tip.golang.org/pkg/os/exec/#LookPath) no longer allow results from a PATH search to be found relative to the current directory.

Although this is not updating the version used on docker images it would be good to check your team's services to see if this might break something.