### PR TITLE
chore: bump lykon-service chart version

### DIFF
--- a/.github/workflows/release-deploy.yaml
+++ b/.github/workflows/release-deploy.yaml
@@ -56,7 +56,7 @@ jobs:
       with:
         helm: helm3
         chart: lykon-charts/lykon-service
-        chart-version: "0.10.12"
+        chart-version: "0.10.14"
         track: stable
         version: ${{ github.sha }}
         token: ${{ github.token }}


### PR DESCRIPTION
#### What does this PR do?
- updates the shared`lykon-service` helm chart version