### PR TITLE
Disable provenance temporarily due to buildx issue

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -83,6 +83,7 @@ jobs:
         file: ${{ inputs.docker_file_path }}
         push: true
         tags: ${{ steps.metadata-srv.outputs.tags }}
+        provenance: false
         build-args: |
           GITHUB_TOKEN=${{ secrets.GB_TOKEN_PRIVATE }}
           ${{ inputs.build_args }}


### PR DESCRIPTION
See: https://github.com/docker/buildx/issues/1533