### PR TITLE
fix(crossplane): correct prod cluster_name to prd-v2

### DIFF
--- a/crossplane/prod.tfvars
+++ b/crossplane/prod.tfvars
@@ -1,2 +1,2 @@
-cluster_name = "prod-eks-v2"
+cluster_name = "prd-v2"
 vault_id = "37y43e5v2qd3iptgt7wgyk34ga"


### PR DESCRIPTION
Corrects the hardcoded prod EKS cluster name in `crossplane/prod.tfvars` from `prod-eks-v2` (which does not exist in the Lykon prod account) to `prd-v2`.