### PR TITLE
fix(crossplane): use real eks cluster names (prd-eks-v2 / stg-eks-v2)

### DIFF
--- a/crossplane/prod.tfvars
+++ b/crossplane/prod.tfvars
@@ -1,2 +1,2 @@
-cluster_name = "prd-v2"
+cluster_name = "prd-eks-v2"
 vault_id = "37y43e5v2qd3iptgt7wgyk34ga"

--- a/crossplane/staging.tfvars
+++ b/crossplane/staging.tfvars
@@ -1,2 +1,2 @@
-cluster_name = "staging-eks-v2"
+cluster_name = "stg-eks-v2"
 vault_id = "errsir3kqd4gdjgaxliofyskey"


### PR DESCRIPTION
Follow-up to #156. Confirmed against the live Lykon account (`aws eks list-clusters`, account 279707217826, eu-central-1) that the clusters are **`prd-eks-v2`** and **`stg-eks-v2`**.

- `crossplane/prod.tfvars`: `prd-v2` → `prd-eks-v2` (#156 set the wrong value)
- `crossplane/staging.tfvars`: `staging-eks-v2` → `stg-eks-v2`

As noted in #156, `var.cluster_name` is currently unused by the crossplane module (kubectl provider auths via the `STG_KUBECONFIG` secret), so this is correctness/hygiene. The deploy-blocking lookups live in the service repos and are fixed separately.