### PR TITLE
chore(1p): migrate crossplane 1Password vault ids to new Lykon K8s vaults

### DIFF
--- a/.github/workflows/main-crossplane.yaml
+++ b/.github/workflows/main-crossplane.yaml
@@ -129,7 +129,7 @@ jobs:
           done
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.STAGING_ONEPASSWORD_SERVICEACCOUNT_TOKEN }}
-          VAULT_ID: "errsir3kqd4gdjgaxliofyskey"
+          VAULT_ID: "ueodovtwcjbxlpcxslm4wqrdoe"
 
       - name: patch claim image uri with commit hash
         id: patch_image_uri_with_commit_hash

--- a/.github/workflows/release-crossplane.yaml
+++ b/.github/workflows/release-crossplane.yaml
@@ -115,7 +115,7 @@ jobs:
 
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.PROD_ONEPASSWORD_SERVICEACCOUNT_TOKEN }}
-          VAULT_ID: "37y43e5v2qd3iptgt7wgyk34ga"
+          VAULT_ID: "lrkmmcel3akl3fphaltgoxtdvu"
 
       - name: Terraform apply
         id: apply

--- a/crossplane/modify-claims.sh
+++ b/crossplane/modify-claims.sh
@@ -64,9 +64,9 @@ if [[ " ${CLAIM_TYPES_LAMBDA[@]} " =~ " ${kind} " ]]; then
 elif [[ " ${CLAIM_TYPES_GOAPP[@]} " =~ " ${kind} " ]]; then
   # Handle XLykonGoApp
   if [[ "$ENV" == "staging" ]]; then
-    vault_id="errsir3kqd4gdjgaxliofyskey"
+    vault_id="ueodovtwcjbxlpcxslm4wqrdoe"
   elif [[ "$ENV" == "prod" ]]; then
-    vault_id="37y43e5v2qd3iptgt7wgyk34ga"
+    vault_id="lrkmmcel3akl3fphaltgoxtdvu"
   else
     echo "Error: Unsupported environment $ENV"
     exit 1

--- a/crossplane/prod.tfvars
+++ b/crossplane/prod.tfvars
@@ -1,2 +1,2 @@
 cluster_name = "prd-eks-v2"
-vault_id = "37y43e5v2qd3iptgt7wgyk34ga"
+vault_id = "lrkmmcel3akl3fphaltgoxtdvu"

--- a/crossplane/staging.tfvars
+++ b/crossplane/staging.tfvars
@@ -1,2 +1,2 @@
 cluster_name = "stg-eks-v2"
-vault_id = "errsir3kqd4gdjgaxliofyskey"
+vault_id = "ueodovtwcjbxlpcxslm4wqrdoe"


### PR DESCRIPTION
Lykon is decommissioning the old 1Password account. Swaps the hardcoded crossplane vault ids to the new **Lykon K8s** vaults:

| env | old | new |
|---|---|---|
| prod | `37y43e5v2qd3iptgt7wgyk34ga` | `lrkmmcel3akl3fphaltgoxtdvu` |
| staging | `errsir3kqd4gdjgaxliofyskey` | `ueodovtwcjbxlpcxslm4wqrdoe` |

Touched all 6 occurrences:
- `crossplane/prod.tfvars`, `crossplane/staging.tfvars` (`vault_id`)
- `crossplane/modify-claims.sh` (the hardcoded XLykonGoApp branch + the `op items get --vault` lookup uses these)
- `.github/workflows/release-crossplane.yaml`, `main-crossplane.yaml` (`VAULT_ID` env for patch.py)

Companion PRs follow for `vimeda/kubernetes` and `vimeda/helm-starters`, which also reference the old ids. The new `*_ONEPASSWORD_SERVICEACCOUNT_TOKEN` secrets must be able to read these new vaults.