### PR TITLE
chore(1p): source crossplane vault id from secret (stop hardcoding in public repo)

### DIFF
--- a/.github/workflows/crossplane-release.yaml
+++ b/.github/workflows/crossplane-release.yaml
@@ -157,6 +157,7 @@ jobs:
           # Run terraform apply
           terraform apply -auto-approve -no-color \
             -var-file=${{ inputs.environment }}.tfvars \
+            -var="vault_id=${{ secrets.PROD_ONEPASSWORD_VAULT }}" \
             -var="commit_hash=${{ github.sha }}" \
             -var="service_name=${{ inputs.service_name }}"
         env:

--- a/.github/workflows/crossplane.yaml
+++ b/.github/workflows/crossplane.yaml
@@ -125,6 +125,7 @@ jobs:
           export KUBECONFIG=${{ github.workspace }}/kubeconfig.yaml
           terraform apply -auto-approve -no-color \
           -var-file=${{ inputs.environment }}.tfvars \
+          -var="vault_id=${{ secrets.STAGING_ONEPASSWORD_VAULT }}" \
           -var="commit_hash=${{ github.sha }}" \
           -var="service_name=${{ inputs.service_name }}"
         env:

--- a/.github/workflows/main-crossplane.yaml
+++ b/.github/workflows/main-crossplane.yaml
@@ -129,7 +129,7 @@ jobs:
           done
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.STAGING_ONEPASSWORD_SERVICEACCOUNT_TOKEN }}
-          VAULT_ID: "errsir3kqd4gdjgaxliofyskey"
+          VAULT_ID: ${{ secrets.STAGING_ONEPASSWORD_VAULT }}
 
       - name: patch claim image uri with commit hash
         id: patch_image_uri_with_commit_hash

--- a/.github/workflows/release-crossplane.yaml
+++ b/.github/workflows/release-crossplane.yaml
@@ -115,7 +115,7 @@ jobs:
 
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.PROD_ONEPASSWORD_SERVICEACCOUNT_TOKEN }}
-          VAULT_ID: "37y43e5v2qd3iptgt7wgyk34ga"
+          VAULT_ID: ${{ secrets.PROD_ONEPASSWORD_VAULT }}
 
       - name: Terraform apply
         id: apply

--- a/crossplane/modify-claims.sh
+++ b/crossplane/modify-claims.sh
@@ -62,17 +62,8 @@ if [[ " ${CLAIM_TYPES_LAMBDA[@]} " =~ " ${kind} " ]]; then
   fi
   add_vpc_config "$ENV"  # Add VPC config only for Lambda types
 elif [[ " ${CLAIM_TYPES_GOAPP[@]} " =~ " ${kind} " ]]; then
-  # Handle XLykonGoApp
-  if [[ "$ENV" == "staging" ]]; then
-    vault_id="errsir3kqd4gdjgaxliofyskey"
-  elif [[ "$ENV" == "prod" ]]; then
-    vault_id="37y43e5v2qd3iptgt7wgyk34ga"
-  else
-    echo "Error: Unsupported environment $ENV"
-    exit 1
-  fi
-
-  yq eval ".spec.parameters.vault_id = \"$vault_id\"" -i "$temp_yaml_file"
+  # Handle XLykonGoApp — vault id is provided via $VAULT_ID (env-specific, from terraform var.vault_id)
+  yq eval ".spec.parameters.vault_id = \"$VAULT_ID\"" -i "$temp_yaml_file"
 fi
 
 if [[ "$kind" == "XLykonLambdaDockerImage" || "$kind" == "XEventSourceMapping" ]]; then

--- a/crossplane/prod.tfvars
+++ b/crossplane/prod.tfvars
@@ -1,2 +1,1 @@
 cluster_name = "prd-eks-v2"
-vault_id = "37y43e5v2qd3iptgt7wgyk34ga"

--- a/crossplane/staging.tfvars
+++ b/crossplane/staging.tfvars
@@ -1,2 +1,1 @@
 cluster_name = "stg-eks-v2"
-vault_id = "errsir3kqd4gdjgaxliofyskey"


### PR DESCRIPTION
This repo is **public**, so the 1Password vault ids should not be committed. This sources them from secrets and **removes the hardcoded ids from the repo entirely** (incl. the old ones still on `master`).

### Changes
- `crossplane/prod.tfvars` / `staging.tfvars`: drop the `vault_id` line (now passed at apply time).
- `crossplane.yaml` (staging) / `crossplane-release.yaml` (prod): add `-var="vault_id=${{ secrets.STAGING_ONEPASSWORD_VAULT }}"` / `…PROD_ONEPASSWORD_VAULT`.
- `release-crossplane.yaml` (prod) / `main-crossplane.yaml` (staging): `VAULT_ID` env now reads the secret.
- `modify-claims.sh`: the `XLykonGoApp` branch no longer hardcodes per-env ids — it uses `$VAULT_ID`, which is already env-specific (flows from `var.vault_id`).

### ⚠️ Required before merge — create these secrets
Set at the **same level as the existing `*_ONEPASSWORD_SERVICEACCOUNT_TOKEN` secrets** (org-level on `vimeda`, visibility = all), because these reusable workflows are called with `secrets: inherit` and resolve against the *caller’s* secrets:

| secret | value |
|---|---|
| `PROD_ONEPASSWORD_VAULT` | new **Lykon K8s Prod** vault id |
| `STAGING_ONEPASSWORD_VAULT` | new **Lykon K8s Staging** vault id |

(values intentionally not written here — public PR.)

Once the secrets exist, mark ready + merge. Completes the 1P migration *and* removes the ids from the public repo. Replaces closed #158. Companions: vimeda/kubernetes#834, vimeda/helm-starters#160.