### PR TITLE
chore(1p): source crossplane vault id from secret (feature/shared-crossplane)

### DIFF
--- a/.github/workflows/crossplane-release.yaml
+++ b/.github/workflows/crossplane-release.yaml
@@ -157,7 +157,7 @@ jobs:
           # Run terraform apply
           terraform apply -auto-approve -no-color \
             -var-file=${{ inputs.environment }}.tfvars \
-            -var="vault_id=${{ secrets.PROD_ONEPASSWORD_VAULT }}" \
+            -var="vault_id=${{ secrets.LYKON_PROD_ONEPASSWORD_VAULT }}" \
             -var="commit_hash=${{ github.sha }}" \
             -var="service_name=${{ inputs.service_name }}"
         env:

--- a/.github/workflows/crossplane-release.yaml
+++ b/.github/workflows/crossplane-release.yaml
@@ -157,6 +157,7 @@ jobs:
           # Run terraform apply
           terraform apply -auto-approve -no-color \
             -var-file=${{ inputs.environment }}.tfvars \
+            -var="vault_id=${{ secrets.PROD_ONEPASSWORD_VAULT }}" \
             -var="commit_hash=${{ github.sha }}" \
             -var="service_name=${{ inputs.service_name }}"
         env:

--- a/.github/workflows/crossplane.yaml
+++ b/.github/workflows/crossplane.yaml
@@ -131,6 +131,7 @@ jobs:
           export KUBECONFIG=${{ github.workspace }}/kubeconfig.yaml
           terraform apply -auto-approve -no-color \
           -var-file=${{ inputs.environment }}.tfvars \
+          -var="vault_id=${{ secrets.STAGING_ONEPASSWORD_VAULT }}" \
           -var="commit_hash=${{ github.sha }}" \
           -var="service_name=${{ inputs.service_name }}"
         env:

--- a/.github/workflows/crossplane.yaml
+++ b/.github/workflows/crossplane.yaml
@@ -131,7 +131,7 @@ jobs:
           export KUBECONFIG=${{ github.workspace }}/kubeconfig.yaml
           terraform apply -auto-approve -no-color \
           -var-file=${{ inputs.environment }}.tfvars \
-          -var="vault_id=${{ secrets.STAGING_ONEPASSWORD_VAULT }}" \
+          -var="vault_id=${{ secrets.LYKON_STAGING_ONEPASSWORD_VAULT }}" \
           -var="commit_hash=${{ github.sha }}" \
           -var="service_name=${{ inputs.service_name }}"
         env:

--- a/crossplane/modify-claims.sh
+++ b/crossplane/modify-claims.sh
@@ -68,17 +68,8 @@ if [[ " ${CLAIM_TYPES_LAMBDA[@]} " =~ " ${kind} " ]]; then
   fi
   add_vpc_config "$ENV"  # Add VPC config only for Lambda types
 elif [[ " ${CLAIM_TYPES_GOAPP[@]} " =~ " ${kind} " ]]; then
-  # Handle XLykonGoApp
-  if [[ "$ENV" == "staging" ]]; then
-    vault_id="errsir3kqd4gdjgaxliofyskey"
-  elif [[ "$ENV" == "prod" ]]; then
-    vault_id="37y43e5v2qd3iptgt7wgyk34ga"
-  else
-    echo "Error: Unsupported environment $ENV"
-    exit 1
-  fi
-
-  yq eval ".spec.parameters.vault_id = \"$vault_id\"" -i "$temp_yaml_file"
+  # Handle XLykonGoApp — vault id is provided via $VAULT_ID (env-specific, from terraform var.vault_id)
+  yq eval ".spec.parameters.vault_id = \"$VAULT_ID\"" -i "$temp_yaml_file"
 fi
 
 if [[ "$kind" == "XLykonLambdaDockerImage" || "$kind" == "XEventSourceMapping" ]]; then

--- a/crossplane/prod.tfvars
+++ b/crossplane/prod.tfvars
@@ -1,2 +1,1 @@
 cluster_name = "prd-eks-v2"
-vault_id = "37y43e5v2qd3iptgt7wgyk34ga"

--- a/crossplane/staging.tfvars
+++ b/crossplane/staging.tfvars
@@ -1,2 +1,1 @@
 cluster_name = "staging-eks-v2"
-vault_id = "errsir3kqd4gdjgaxliofyskey"


### PR DESCRIPTION
Targets **`feature/shared-crossplane`** — the branch every service pins (`crossplane-release.yaml@feature/shared-crossplane`), so this is where the 1P migration actually takes effect (the merged-to-`main` #159 does not, since nothing consumes `main`). Also removes the old vault ids from this branch.

### Changes (5 files)
- `crossplane/prod.tfvars` / `staging.tfvars`: drop `vault_id` (now passed at apply).
- `crossplane-release.yaml` (prod): `-var="vault_id=${{ secrets.PROD_ONEPASSWORD_VAULT }}"`.
- `crossplane.yaml` (staging): `-var="vault_id=${{ secrets.STAGING_ONEPASSWORD_VAULT }}"`.
- `modify-claims.sh`: `XLykonGoApp` branch uses `$VAULT_ID` (env-specific) instead of hardcoded ids.

`test-crossplane.yaml` is untouched — it applies the *service*’s `configs/crossplane`, not this module.

### ⚠️ Required before merge — secrets on each calling repo
Because services call this with `secrets: inherit`, `PROD_ONEPASSWORD_VAULT` + `STAGING_ONEPASSWORD_VAULT` must exist on **each crossplane-caller repo** (org-level not available): account-srv, auth-srv, click-protocol-srv, crm-srv, dna-srv, gdpr-deleter-srv, health-profile-srv, helpdesk-srv, impersonation-srv, order-srv, pdf-generator-srv, pdf-srv, portal, prompt-srv, sample-srv, translation-srv. Set to the new Lykon K8s prod/staging vault ids (values not in this public PR).

Companion to `main` #159.