### PR TITLE
chore(1p): use LYKON_ONEPASSWORD_SERVICE_ACCOUNT for op auth (main)

### DIFF
--- a/.github/workflows/crossplane-release.yaml
+++ b/.github/workflows/crossplane-release.yaml
@@ -162,7 +162,7 @@ jobs:
             -var="service_name=${{ inputs.service_name }}"
         env:
           TF_WORKSPACE: ${{ inputs.environment }}
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.PROD_ONEPASSWORD_SERVICEACCOUNT_TOKEN }}
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.LYKON_ONEPASSWORD_SERVICE_ACCOUNT }}
           AWS_DEFAULT_REGION: eu-central-1
 
 

--- a/.github/workflows/crossplane.yaml
+++ b/.github/workflows/crossplane.yaml
@@ -130,6 +130,6 @@ jobs:
           -var="service_name=${{ inputs.service_name }}"
         env:
           TF_WORKSPACE: ${{ inputs.environment }}
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.STAGING_ONEPASSWORD_SERVICEACCOUNT_TOKEN }}
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.LYKON_ONEPASSWORD_SERVICE_ACCOUNT }}
 
 

--- a/.github/workflows/main-crossplane.yaml
+++ b/.github/workflows/main-crossplane.yaml
@@ -128,7 +128,7 @@ jobs:
               fi
           done
         env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.STAGING_ONEPASSWORD_SERVICEACCOUNT_TOKEN }}
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.LYKON_ONEPASSWORD_SERVICE_ACCOUNT }}
           VAULT_ID: ${{ secrets.STAGING_ONEPASSWORD_VAULT }}
 
       - name: patch claim image uri with commit hash

--- a/.github/workflows/release-crossplane.yaml
+++ b/.github/workflows/release-crossplane.yaml
@@ -114,7 +114,7 @@ jobs:
           done
 
         env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.PROD_ONEPASSWORD_SERVICEACCOUNT_TOKEN }}
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.LYKON_ONEPASSWORD_SERVICE_ACCOUNT }}
           VAULT_ID: ${{ secrets.PROD_ONEPASSWORD_VAULT }}
 
       - name: Terraform apply


### PR DESCRIPTION
Repoints `OP_SERVICE_ACCOUNT_TOKEN` in the crossplane workflows to the new-account 1Password service-account token **`secrets.LYKON_ONEPASSWORD_SERVICE_ACCOUNT`** (org-level secret), replacing the old-account `PROD_/STAGING_ONEPASSWORD_SERVICEACCOUNT_TOKEN`.

One service account covers both vaults, so prod (`crossplane-release.yaml`, `release-crossplane.yaml`) and staging (`crossplane.yaml`, `main-crossplane.yaml`) both use it.

Completes the 1P migration alongside the merged `LYKON_*_ONEPASSWORD_VAULT` change. Companion PR on `feature/shared-crossplane` (the branch services pin). Merge once the new vaults are populated + the SA token is confirmed working.