### PR TITLE
chore(1p): use LYKON_ONEPASSWORD_SERVICE_ACCOUNT for op auth (feature/shared-crossplane)

### DIFF
--- a/.github/workflows/crossplane-release.yaml
+++ b/.github/workflows/crossplane-release.yaml
@@ -162,7 +162,7 @@ jobs:
             -var="service_name=${{ inputs.service_name }}"
         env:
           TF_WORKSPACE: ${{ inputs.environment }}
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.PROD_ONEPASSWORD_SERVICEACCOUNT_TOKEN }}
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.LYKON_ONEPASSWORD_SERVICE_ACCOUNT }}
           AWS_DEFAULT_REGION: eu-central-1
 
 

--- a/.github/workflows/crossplane.yaml
+++ b/.github/workflows/crossplane.yaml
@@ -136,4 +136,4 @@ jobs:
           -var="service_name=${{ inputs.service_name }}"
         env:
           TF_WORKSPACE: ${{ inputs.environment }}
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.STAGING_ONEPASSWORD_SERVICEACCOUNT_TOKEN }}
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.LYKON_ONEPASSWORD_SERVICE_ACCOUNT }}


### PR DESCRIPTION
Repoints `OP_SERVICE_ACCOUNT_TOKEN` → **`secrets.LYKON_ONEPASSWORD_SERVICE_ACCOUNT`** (new-account SA token, org-level) in `crossplane.yaml` (staging) + `crossplane-release.yaml` (prod) on the branch services actually pin. Replaces the old-account `PROD_/STAGING_ONEPASSWORD_SERVICEACCOUNT_TOKEN`. Companion to #161 (main). Merge once the new vaults are populated + SA token verified.