### PR TITLE
chore(1p): prefix crossplane vault secret refs with LYKON_

### DIFF
--- a/.github/workflows/crossplane-release.yaml
+++ b/.github/workflows/crossplane-release.yaml
@@ -157,7 +157,7 @@ jobs:
           # Run terraform apply
           terraform apply -auto-approve -no-color \
             -var-file=${{ inputs.environment }}.tfvars \
-            -var="vault_id=${{ secrets.PROD_ONEPASSWORD_VAULT }}" \
+            -var="vault_id=${{ secrets.LYKON_PROD_ONEPASSWORD_VAULT }}" \
             -var="commit_hash=${{ github.sha }}" \
             -var="service_name=${{ inputs.service_name }}"
         env:

--- a/.github/workflows/crossplane.yaml
+++ b/.github/workflows/crossplane.yaml
@@ -125,7 +125,7 @@ jobs:
           export KUBECONFIG=${{ github.workspace }}/kubeconfig.yaml
           terraform apply -auto-approve -no-color \
           -var-file=${{ inputs.environment }}.tfvars \
-          -var="vault_id=${{ secrets.STAGING_ONEPASSWORD_VAULT }}" \
+          -var="vault_id=${{ secrets.LYKON_STAGING_ONEPASSWORD_VAULT }}" \
           -var="commit_hash=${{ github.sha }}" \
           -var="service_name=${{ inputs.service_name }}"
         env:


### PR DESCRIPTION
## What
`crossplane.yaml` and `crossplane-release.yaml` referenced `secrets.STAGING_ONEPASSWORD_VAULT` / `secrets.PROD_ONEPASSWORD_VAULT`, but the actual per-repo secrets are named `LYKON_STAGING_ONEPASSWORD_VAULT` / `LYKON_PROD_ONEPASSWORD_VAULT`.

## Why
These reusable workflows are called with `secrets: inherit`, so the secret names resolve against the **caller** service repo. The unprefixed names don't exist there → they resolve to empty → deploys ran `-var="vault_id="`, **blanking** the 1Password vault on the rendered claim instead of pointing it at the new Lykon vault. Confirmed live on a sample-srv staging redeploy (`vault_id: "errsir3…" -> ""`).

## Context
#159 merged the "source vault id from a secret" change but with the **unprefixed** names; the follow-up `LYKON_` prefix commit (`3ee95c2`) was stranded on `chore/1p-vault-to-secrets` and never merged. This re-applies just that 2-line prefix fix onto current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)